### PR TITLE
feat(dashboard): implementación completa de gráficos y tabla para resumen y monitoreo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@vee-validate/rules": "^4.15.0",
         "@vee-validate/yup": "^4.15.0",
         "axios": "^1.7.9",
+        "chart.js": "^4.4.8",
         "date-fns": "^4.1.0",
         "jwt-decode": "^4.0.0",
         "lodash.merge": "^4.6.2",
@@ -1256,6 +1257,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3158,6 +3165,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
+      "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vee-validate/rules": "^4.15.0",
     "@vee-validate/yup": "^4.15.0",
     "axios": "^1.7.9",
+    "chart.js": "^4.4.8",
     "date-fns": "^4.1.0",
     "jwt-decode": "^4.0.0",
     "lodash.merge": "^4.6.2",

--- a/src/core/services/dashboardService.ts
+++ b/src/core/services/dashboardService.ts
@@ -1,0 +1,35 @@
+
+import { apiClient } from "@/core/common/configuration/axiosClient.ts";
+import type { ReportsSummaryResponse, ReportsSeverityResponse, TopUsersResponse, AverageResolutionTimeResponse } from "@/core/types/dashboard.ts";
+
+/**
+ * Obtiene el resumen general de los reportes.
+ */
+export async function getReportsSummary(): Promise<ReportsSummaryResponse> {
+  const { data } = await apiClient.get("/Dashboard/reports-summary");
+  return data;
+}
+
+/**
+ * Obtiene el conteo de reportes por severidad.
+ */
+export async function getReportsSeverity(): Promise<ReportsSeverityResponse> {
+  const { data } = await apiClient.get("/Dashboard/reports-severity");
+  return data;
+}
+
+/**
+ * Obtiene el listado de los usuarios con más reportes.
+ */
+export async function getTopUsers(): Promise<TopUsersResponse> {
+  const { data } = await apiClient.get("/Dashboard/top-users");
+  return data;
+}
+
+/**
+ * Obtiene el promedio de tiempo de resolución de reportes.
+ */
+export async function getAverageResolutionTime(): Promise<AverageResolutionTimeResponse> {
+  const { data } = await apiClient.get("/Dashboard/average-resolution-time");
+  return data;
+}

--- a/src/core/stores/authStore.ts
+++ b/src/core/stores/authStore.ts
@@ -31,6 +31,7 @@ export const useAuthStore = defineStore('auth', () => {
 
     if (value) {
       const decoded = jwtDecode<TokenPayload>(value);
+      console.log(decoded);
       permissions.value = decoded.permissions ? decoded.permissions.split(',') : [];
       decodedUserId.value = decoded.nameid ?? null;
       fetchUserInfo(decodedUserId.value);

--- a/src/core/types/dashboard.ts
+++ b/src/core/types/dashboard.ts
@@ -1,0 +1,29 @@
+// src/core/types/dashboard.ts
+
+export interface ReportsSummaryResponse {
+  totalReports: number;
+  pendingReports: number;
+  inProgressReports: number;
+  resolvedReports: number;
+}
+
+export interface ReportsSeverityResponse {
+  totalReports: number;
+  lowSeverity: number;
+  mediumSeverity: number;
+  highSeverity: number;
+}
+
+export interface TopUser {
+  id: string;
+  name: string;
+  email: string;
+  reportsCount: number;
+}
+
+export type TopUsersResponse = TopUser[];
+
+export interface AverageResolutionTimeResponse {
+  averageDays: number;
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,8 @@ import IconField from 'primevue/iconfield';
 import InputIcon from 'primevue/inputicon';
 import Toolbar from 'primevue/toolbar';
 import MultiSelect from 'primevue/multiselect';
+import Chart from 'primevue/chart';
+
 
 // Importaciones de componentes PrimeVue para el Mapa
 import Tag from 'primevue/tag';
@@ -85,6 +87,7 @@ app.component('IconField', IconField);
 app.component('InputIcon', InputIcon);
 app.component('Toolbar', Toolbar);
 app.component('MultiSelect', MultiSelect);
+app.component('Chart', Chart);
 
 //Nuevos componentes del mapa
 app.component('Tag', Tag);

--- a/src/shared/components/admin/DashboardReportsChart.vue
+++ b/src/shared/components/admin/DashboardReportsChart.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue';
+import { useLayoutStore } from '@/core/stores/useLayoutStore';
+import { getReportsSummary } from '@/core/services/dashboardService';
+import type { ReportsSummaryResponse } from '@/core/types/dashboard';
+import Chart from 'primevue/chart';
+
+// Layout Store para detectar tema y colores dinámicos
+const layoutStore = useLayoutStore();
+const { layoutConfig } = layoutStore;
+
+const chartData = ref();
+const chartOptions = ref();
+
+// Datos desde backend
+const summaryData = ref<ReportsSummaryResponse | null>(null);
+
+// Cargar datos
+async function loadSummaryData() {
+  try {
+    summaryData.value = await getReportsSummary();
+    chartData.value = setChartData();
+    chartOptions.value = setChartOptions();
+  } catch (error) {
+    console.error('Error al cargar resumen:', error);
+  }
+}
+
+// Configuración del gráfico
+function setChartData() {
+
+  return {
+    labels: ['Pendientes', 'En progreso', 'Resueltos'],
+    datasets: [
+      {
+        data: [
+          summaryData.value?.pendingReports || 0,
+          summaryData.value?.inProgressReports || 0,
+          summaryData.value?.resolvedReports || 0
+        ],
+        backgroundColor: [
+          'rgba(239, 68, 68, 0.6)',  // rojo con 60%
+          'rgba(251, 191, 36, 0.6)', // amarillo con 60%
+          'rgba(34, 197, 94, 0.6)'   // verde con 60%
+        ],
+        hoverBackgroundColor: [
+          'rgba(239, 68, 68, 0.8)',
+          'rgba(251, 191, 36, 0.8)',
+          'rgba(34, 197, 94, 0.8)'
+        ],
+        borderWidth: 1
+      }
+    ]
+  };
+}
+
+// Opciones del gráfico
+function setChartOptions() {
+  const documentStyle = getComputedStyle(document.documentElement);
+  const textColor = documentStyle.getPropertyValue('--text-color');
+
+  return {
+    cutout: '40%',
+    plugins: {
+      legend: {
+        labels: {
+          color: textColor
+        }
+      }
+    }
+  };
+}
+
+// Detecta cambio de tema
+watch(() => layoutConfig, () => {
+  if (summaryData.value) {
+    chartData.value = setChartData();
+    chartOptions.value = setChartOptions();
+  }
+}, { deep: true });
+
+// Inicializa
+onMounted(() => {
+  loadSummaryData();
+});
+</script>
+
+<template>
+  <div class="card flex flex-col justify-center items-center">
+    <h4 class="text-lg font-semibold mb-4">Resumen de Reportes</h4>
+    <Chart type="doughnut" :data="chartData" :options="chartOptions" class="w-full h-80 flex justify-center" />
+  </div>
+</template>

--- a/src/shared/components/admin/DashboardSeverityChart.vue
+++ b/src/shared/components/admin/DashboardSeverityChart.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import { useLayoutStore } from '@/core/stores/useLayoutStore';
+import { getReportsSeverity } from '@/core/services/dashboardService';
+import type { ReportsSeverityResponse } from '@/core/types/dashboard';
+import Chart from 'primevue/chart';
+
+const layoutStore = useLayoutStore();
+const { layoutConfig } = layoutStore;
+
+// Chart Data & Options
+const chartData = ref();
+const chartOptions = ref();
+
+// Datos desde backend
+const severityData = ref<ReportsSeverityResponse | null>(null);
+
+// Flag de "no hay datos"
+const noData = ref(false);
+
+// Función para cargar los datos
+async function loadSeverityData() {
+  try {
+    severityData.value = await getReportsSeverity();
+
+    const total = (severityData.value?.highSeverity || 0) +
+                  (severityData.value?.mediumSeverity || 0) +
+                  (severityData.value?.lowSeverity || 0);
+
+    if (total === 0) {
+      noData.value = true;
+    } else {
+      noData.value = false;
+      chartData.value = setChartData();
+      chartOptions.value = setChartOptions();
+    }
+
+  } catch (error) {
+    console.error('Error al cargar severidad:', error);
+    noData.value = true;
+  }
+}
+
+// Configurar datos del gráfico
+function setChartData() {
+  return {
+    labels: ['Alta Severidad', 'Media Severidad', 'Baja Severidad'],
+    datasets: [
+      {
+        type: 'bar',
+        label: 'Alta Severidad',
+        backgroundColor: 'rgba(239, 68, 68, 0.6)', // rojo con transparencia
+        data: [severityData.value?.highSeverity || 0, 0, 0],
+        barThickness: 40
+      },
+      {
+        type: 'bar',
+        label: 'Media Severidad',
+        backgroundColor: 'rgba(245, 158, 11, 0.6)', // amarillo con transparencia
+        data: [0, severityData.value?.mediumSeverity || 0, 0],
+        barThickness: 40
+      },
+      {
+        type: 'bar',
+        label: 'Baja Severidad',
+        backgroundColor: 'rgba(59, 130, 246, 0.6)', // azul con transparencia
+        data: [0, 0, severityData.value?.lowSeverity || 0],
+        barThickness: 40
+      }
+    ]
+  };
+}
+
+// Opciones de la gráfica
+function setChartOptions() {
+  const documentStyle = getComputedStyle(document.documentElement);
+  const borderColor = documentStyle.getPropertyValue('--surface-border');
+  const textMutedColor = documentStyle.getPropertyValue('--text-color-secondary');
+
+  return {
+    maintainAspectRatio: false,
+    aspectRatio: 0.8,
+    plugins: {
+      legend: {
+        labels: {
+          color: textMutedColor
+        }
+      }
+    },
+    scales: {
+      x: {
+        ticks: { color: textMutedColor },
+        grid: { color: 'transparent', borderColor: 'transparent' }
+      },
+      y: {
+        ticks: { color: textMutedColor },
+        grid: { color: borderColor, borderColor: 'transparent', drawTicks: false }
+      }
+    }
+  };
+}
+
+// Re-renderiza cuando cambian colores o tema
+watch(() => layoutConfig, () => {
+  if (severityData.value && !noData.value) {
+    chartData.value = setChartData();
+    chartOptions.value = setChartOptions();
+  }
+}, { deep: true });
+
+// Inicializa
+onMounted(() => {
+  loadSeverityData();
+});
+</script>
+
+<template>
+  <div class="card">
+    <div class="font-semibold text-xl mb-4">Reportes por Severidad</div>
+
+    <!-- Si no hay datos -->
+    <div v-if="noData" class="text-center text-gray-500 py-10">
+      No hay reportes disponibles.
+    </div>
+
+    <!-- Si hay datos -->
+    <Chart
+      v-else
+      type="bar"
+      :data="chartData"
+      :options="chartOptions"
+      class="h-80"
+    />
+  </div>
+</template>

--- a/src/shared/components/admin/DashboardTopUsersChart.vue
+++ b/src/shared/components/admin/DashboardTopUsersChart.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import type { ChartData, ChartOptions } from 'chart.js';
+import Chart from 'primevue/chart';
+import { getTopUsers } from '@/core/services/dashboardService';
+import type { TopUser } from '@/core/types/dashboard';
+
+const chartData = ref<ChartData<'bar'>>({
+  labels: [],
+  datasets: [
+    {
+      label: 'Número de Reportes',
+      data: [],
+      backgroundColor: 'rgba(75, 192, 192, 0.6)',
+      borderColor: 'rgba(75, 192, 192, 1)',
+      borderWidth: 1,
+    },
+  ],
+});
+
+const chartOptions = ref<ChartOptions<'bar'>>({
+  indexAxis: 'y', // Horizontal Bar
+  responsive: true,
+  scales: {
+    x: { beginAtZero: true, ticks: { stepSize: 1 } },
+  },
+});
+
+onMounted(async () => {
+  const topUsers: TopUser[] = await getTopUsers();
+
+  // 🔥 Filtrar solo usuarios con reportes >= 1
+  const filteredUsers = topUsers.filter((user) => user.reportsCount >= 1);
+
+  chartData.value.labels = filteredUsers.map((user) => user.name);
+  chartData.value.datasets[0].data = filteredUsers.map((user) => user.reportsCount);
+});
+</script>
+
+<template>
+  <div class="card">
+    <h4 class="text-lg font-semibold mb-4">Top Usuarios por Número de Reportes</h4>
+    <Chart type="bar" :data="chartData" :options="chartOptions" class="h-96" />
+  </div>
+</template>

--- a/src/shared/components/admin/DashboardTopUsersTable.vue
+++ b/src/shared/components/admin/DashboardTopUsersTable.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="card">
+    <h4 class="text-lg font-semibold mb-4">Lista de Usuarios con más Reportes</h4>
+
+    <DataTable
+      :value="topUsers"
+      :filters="filters"
+      paginator
+      :rows="5"
+      :rowsPerPageOptions="[5, 10, 25]"
+      filterDisplay="menu"
+      dataKey="id"
+      :globalFilterFields="['name', 'email']"
+      class="shadow"
+    >
+      <template #header>
+        <div class="flex flex-wrap gap-2 items-center justify-between">
+          <IconField iconPosition="left">
+            <InputIcon>
+              <i class="pi pi-search text-gray-500" />
+            </InputIcon>
+            <InputText v-model="filters['global'].value" placeholder="Buscar usuarios" class="border border-gray-300 rounded-md p-2" />
+          </IconField>
+        </div>
+      </template>
+
+      <Column field="name" header="Nombre" sortable />
+      <Column field="email" header="Email" sortable />
+      <Column field="reportsCount" header="Número de Reportes" sortable />
+
+      <template #empty> <div class="text-center py-8 text-gray-500">No se encontraron usuarios.</div> </template>
+    </DataTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { getTopUsers } from '@/core/services/dashboardService';
+import type { TopUser } from '@/core/types/dashboard';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import InputText from 'primevue/inputtext';
+import { FilterMatchMode } from '@primevue/core/api';
+
+const topUsers = ref<TopUser[]>([]);
+const filters = ref({
+  global: { value: null, matchMode: FilterMatchMode.CONTAINS }
+});
+
+// ✅ Aquí aplicamos el filtro
+async function loadTopUsers() {
+  const response = await getTopUsers();
+  topUsers.value = response.filter(user => user.reportsCount >= 1);
+}
+
+onMounted(() => {
+  loadTopUsers();
+});
+</script>

--- a/src/views/admin/Permisions/PermissionsCRUD.vue
+++ b/src/views/admin/Permisions/PermissionsCRUD.vue
@@ -107,6 +107,9 @@ async function savePermission() {
       :filters="filters"
       filterDisplay="menu"
       class="shadow"
+      :paginator="true"
+      :rows="10"
+      :rowsPerPageOptions="[5, 10, 25]"
     >
       <!-- Toolbar y filtro -->
       <Toolbar class="flex flex-col md:flex-row items-center justify-between mb-4 gap-4">

--- a/src/views/admin/dashboard/DashboardView.vue
+++ b/src/views/admin/dashboard/DashboardView.vue
@@ -1,11 +1,27 @@
 <script setup lang="ts">
-import {Button} from 'primevue'
+import DashboardReportsChart from '@/shared/components/admin/DashboardReportsChart.vue';
+import DashboardSeverityChart from '@/shared/components/admin/DashboardSeverityChart.vue';
+import DashboardTopUsersChart from '@/shared/components/admin/DashboardTopUsersChart.vue';
+import DashboardTopUsersTable from '@/shared/components/admin/DashboardTopUsersTable.vue';
 </script>
 
 <template>
-<h1>
-  Plantilla de la vista DASHBOARD
-</h1>
+  <div class="max-w-7xl mx-auto p-4 gap">
 
-  <Button>Boton</Button>
+
+  <h3 class="text-2xl font-bold mb-6">
+    DASHBOARD
+  </h3>
+
+  <!-- GRID -->
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <!-- Primera fila -->
+    <DashboardSeverityChart />
+    <DashboardReportsChart />
+
+    <!-- Segunda fila -->
+    <DashboardTopUsersChart />
+    <DashboardTopUsersTable />
+  </div>
+</div>
 </template>


### PR DESCRIPTION
- Se implementan y tipan los servicios para consumir el resumen del dashboard:
  - Nuevo archivo `dashboardService.ts` con funciones para obtener resumen de reportes, severidad, top usuarios y tiempo promedio de resolución.
  - Nuevas interfaces tipadas en `dashboard.ts` para estructurar las respuestas del backend.

- Se crean 4 nuevos componentes en Vue para visualizar los datos del dashboard:
  - `DashboardReportsChart.vue`: Gráfica de dona para resumen de reportes (pendientes, en progreso, resueltos).
  - `DashboardSeverityChart.vue`: Gráfica de barras para distribución por severidad (baja, media, alta).
  - `DashboardTopUsersChart.vue`: Gráfica horizontal para mostrar top usuarios por cantidad de reportes.
  - `DashboardTopUsersTable.vue`: Tabla con filtros y búsqueda para mostrar el listado de usuarios con más reportes.

- Se integra la vista del dashboard en `DashboardView.vue` organizando los 4 componentes en una distribución simétrica.

- Ajustes menores en `PermissionsCRUD.vue` para gregar la paginación, `authStore.ts` y `main.ts` para la integración completa.
